### PR TITLE
ossm: downstream sync: fix empty commit failure

### DIFF
--- a/ossm/merge_upstream.sh
+++ b/ossm/merge_upstream.sh
@@ -56,5 +56,7 @@ merge
 [[ $? -ne 0 ]] && echo "Merge failed." >&2 && exit 1
 
 cargo vendor
-git add .
-git -c "user.name=$GIT_USERNAME" -c "user.email=$GIT_EMAIL" commit -m "update cargo deps"
+if [ -n "$(git status --porcelain)" ]; then
+  git add .
+  git -c "user.name=$GIT_USERNAME" -c "user.email=$GIT_EMAIL" commit -m "update cargo deps"
+fi


### PR DESCRIPTION
Currently the syncing job fails if cargo vendor doesn't add anything new, see [logs](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63596/rehearse-63596-periodic-ci-openshift-service-mesh-ztunnel-release-1.24-sync-upstream-ztunnel-1.24/1929913871305281536).