### PR TITLE
fix TLSv1.2 support by adding missing ciphersuites (#26)

### DIFF
--- a/src/tls/lib.rs
+++ b/src/tls/lib.rs
@@ -84,6 +84,8 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
     if *TLS12_ENABLED {
         // Add TLS 1.2 FIPS-compatible cipher suites
         cipher_suites.extend([
+            rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            rustls::crypto::ring::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             rustls::crypto::ring::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         ]);
@@ -103,6 +105,8 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
     if *TLS12_ENABLED {
         // Add TLS 1.2 FIPS-compatible cipher suites
         cipher_suites.extend([
+            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         ]);
@@ -128,6 +132,8 @@ pub(super) fn provider() -> Arc<CryptoProvider> {
     if *TLS12_ENABLED {
         // Add TLS 1.2 FIPS-compatible cipher suites
         cipher_suites.extend([
+            rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
             rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         ]);


### PR DESCRIPTION
It turns out that Istio's SPIFFE certs use ECDSA certificates, which only became a problem once I started testing against waypoint proxies. This adds the missing CipherSuites (which are still FIPS-compliant of course) to unblock Waypoint->ZTunnel communication.