### PR TITLE
Cherry-pick downstream changes to release-1.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,9 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1849,7 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3072,8 +3074,7 @@ dependencies = [
 [[package]]
 name = "rustls-openssl"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f161084062dd5a443adfb0de9bbfab62699333e2d8424ca91da5f22ec88d1"
+source = "git+https://github.com/tofay/rustls-openssl?rev=a21035c#a21035c0ff42c78cfbce4ba15f8c1e0dd3c09660"
 dependencies = [
  "foreign-types 0.3.2",
  "once_cell",
@@ -4104,7 +4105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ boring-sys = { version = "4", optional = true }
 ring = { version = "0.17", optional = true }
 
 # Enabled with 'tls-openssl'
-rustls-openssl = { version = "0.3", optional = true, features = ["tls12"]}
+rustls-openssl = { git = "https://github.com/tofay/rustls-openssl", rev = "a21035c", optional = true, features = ["tls12"]}
 openssl = { version = "0.10", optional = true }
 openssl-sys = { version = "0.9", optional = true }
 

--- a/ossm/ci/post-submit.sh
+++ b/ossm/ci/post-submit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -exo pipefail
+
+GCS_PROJECT=${GCS_PROJECT:-maistra-prow-testing}
+ARTIFACTS_GCS_PATH=${ARTIFACTS_GCS_PATH:-gs://maistra-prow-testing/ztunnel}
+
+time cargo build --release --features tls-openssl --no-default-features
+
+gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+gcloud config set project "${GCS_PROJECT}"
+
+# Copy artifacts to GCS
+SHA="$(git rev-parse --verify HEAD)"
+
+case $(uname -m) in
+  "x86_64") export ARCH=amd64;;
+  "aarch64") export ARCH=arm64 ;;
+  *) echo "unsupported architecture"; exit 1;;
+esac
+
+gsutil cp ./out/rust/release/ztunnel "${ARTIFACTS_GCS_PATH}/ztunnel-${SHA}-${ARCH}"

--- a/ossm/ci/pre-submit.sh
+++ b/ossm/ci/pre-submit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+time cargo build --release --features tls-openssl --no-default-features


### PR DESCRIPTION
From https://github.com/openshift-service-mesh/ztunnel/tree/release-1.28

**Full cherry-pick:**
- PR #24: update rustl-openssl to include hkdf_info fix from upstream - commit 0f4a0bfdcf5368da4b22f8bb2820d7c14682f0e0

~~Applied small differences with upstream:~~
~~- PR #23: PQC: openssl crypto provider support - commit 1622277cfbc29ff1ba768ab320c23b6b14170edf~~

**Fixed in upstream:**
- PR #26: fix TLSv1.2 support by adding missing ciphersuites - commit 329717d0bd8e63260e459b7edd2a3b6e3d988e69

Added:
https://github.com/openshift-service-mesh/ztunnel/pull/29/changes/5926651835fbf915423f9408b7dc5270276b7ebf

