### PR TITLE
add codebase documentation for AI coding agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ out/
 var/
 .idea/
 .vscode/
+docs/agents/.claims.yml
+docs/agents/STATUS.md
+.scribe/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# ztunnel-ossm — Agentic Documentation Hub
+
+Ztunnel is the node proxy component of Istio ambient mesh, providing transparent L4 traffic handling with mTLS via HBONE tunneling. This is the OpenShift Service Mesh (OSSM) downstream fork.
+
+## Quick Reference
+
+- **Language:** Rust (edition 2024, MSRV 1.90)
+- **Build:** `cargo build --no-default-features -F tls-openssl` / `TLS_MODE=openssl make build` (container builds via `BUILD_WITH_CONTAINER=1`)
+- **Test:** `cargo test --no-default-features -F tls-openssl` / `TLS_MODE=openssl make test` (namespaced tests require `--privileged`)
+- **TLS backend:** OpenSSL (via `rustls-openssl`). This OSSM fork exclusively uses the `tls-openssl` feature.
+
+## Documentation Topics
+
+- [Proxy Data Plane](docs/agents/proxy-data-plane.md) — Inbound/outbound proxy, HBONE, SOCKS5, connection pooling
+- [TLS and Crypto](docs/agents/tls-and-crypto.md) — TLS via rustls+OpenSSL, certificates, identity/auth
+- [xDS and State Management](docs/agents/xds-and-state.md) — xDS client, workload/policy/service state
+- [In-Pod Mode](docs/agents/inpod-mode.md) — Network namespace management, in-pod workload lifecycle
+- [DNS Resolution](docs/agents/dns-resolution.md) — DNS forwarding, resolution, and server
+- [Observability](docs/agents/observability.md) — Metrics, telemetry, admin server, readiness
+- [Build and Testing](docs/agents/build-and-testing.md) — Cargo features, Makefiles, CI, Docker, test infrastructure
+
+## Conventions
+
+- See individual topic files for area-specific patterns
+- Status dashboard: [docs/agents/STATUS.md](docs/agents/STATUS.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+@include AGENTS.md
+
+# Claude-Specific Instructions
+
+## Build Commands
+
+Always use the OpenSSL backend. Never run bare `cargo build` or `cargo test` — the default feature (`tls-aws-lc`) is wrong for this fork.
+
+```
+cargo build --no-default-features -F tls-openssl
+cargo test --no-default-features -F tls-openssl
+cargo clippy --no-default-features -F tls-openssl
+TLS_MODE=openssl make build
+TLS_MODE=openssl make test
+```
+
+## Before Making Changes
+
+- Read the relevant topic file in `docs/agents/` before touching a subsystem. It lists entry points, patterns, and gotchas that will save you from common mistakes.
+- This is an OSSM downstream fork of upstream `istio/ztunnel`. Be aware of what is upstream code vs OSSM-specific (e.g., `MESH_CIPHER_SUITES` env var, `ossm/ci/` scripts, `rustls-openssl` git pin).
+
+## Code Style
+
+- Follow existing patterns in the file you're editing. The codebase uses `strng` (interned strings) extensively — don't replace with `String`.
+- No unnecessary abstractions. This is a performance-critical proxy.
+- Clippy allows `borrow_interior_mutable_const` and `declare_interior_mutable_const` for the `strng` type — don't try to "fix" these.
+
+## Testing
+
+- `tests/direct.rs` — runs without privileges, safe to run anywhere.
+- `tests/namespaced.rs` — requires Linux `--privileged` container with network namespace support. Don't expect these to pass in unprivileged environments.
+- Always add `--no-default-features -F tls-openssl` to test commands.
+
+## Things to Avoid
+
+- Do not change the TLS feature flags or add `tls-aws-lc`/`tls-ring`/`tls-boring` to build commands. This fork only supports OpenSSL.
+- Do not run `cargo build` without `--no-default-features -F tls-openssl`.
+- Do not modify files under `common/` — these are synced from `istio/common-files` via `make update-common`.

--- a/docs/agents/build-and-testing.md
+++ b/docs/agents/build-and-testing.md
@@ -1,0 +1,134 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 20
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "Cargo.toml"
+    - "Makefile"
+    - "Makefile.core.mk"
+    - "Makefile.overrides.mk"
+    - "Containerfile"
+    - "scripts/release.sh"
+    - "scripts/test-with-coverage.sh"
+    - "ossm/ci/pre-submit.sh"
+    - "ossm/ci/post-submit.sh"
+    - "tests/direct.rs"
+    - "tests/namespaced.rs"
+  stale_flags: []
+---
+
+# Build and Testing
+
+> This doc covers ztunnel's build system, Cargo features, Makefile targets, container builds,
+> CI pipelines, and test infrastructure. This OSSM fork exclusively builds with the OpenSSL
+> backend (`--no-default-features -F tls-openssl`). For runtime behavior of the proxy, see
+> [proxy-data-plane.md](proxy-data-plane.md). For TLS details, see [tls-and-crypto.md](tls-and-crypto.md).
+
+## Key Entry Points
+- `Cargo.toml`: Package definition (edition 2024, MSRV 1.90), feature flags, dependencies, build profiles.
+- `Makefile`: Top-level entry point. Delegates to `Makefile.core.mk` for local builds or `common/scripts/run.sh` for containerized builds (controlled by `BUILD_WITH_CONTAINER`).
+- `Makefile.core.mk`: Core build targets: `build`, `test`, `lint`, `check`, `check-features`, `presubmit`, `release`, `format`, `gen`, `cve-check`, `license-check`.
+- `Makefile.overrides.mk`: OSSM-specific overrides — defaults `BUILD_WITH_CONTAINER=1`, adds `--privileged` and netns volume mounts.
+- `Containerfile`: Minimal container image — copies `out/rust/release/ztunnel` binary into `gcr.io/istio-release/base` image.
+- `scripts/release.sh`: Upstream release build and upload to GCS. Use `TLS_MODE=openssl` or invoke OSSM CI scripts directly.
+- `ossm/ci/pre-submit.sh`: OSSM pre-submit — `cargo build --release --features tls-openssl --no-default-features`.
+- `ossm/ci/post-submit.sh`: OSSM post-submit — builds with tls-openssl, uploads binary to GCS (`maistra-prow-testing` bucket).
+- `tests/direct.rs`: Unit/integration tests that run without network namespaces. Test lifecycle, connections, config dump, DNS, proxy modes.
+- `tests/namespaced.rs`: Integration tests using real Linux network namespaces. Test HBONE, mTLS, waypoints, double-HBONE, policies, load balancing, shutdown behavior.
+
+## Patterns & Conventions
+
+### Cargo Feature Flags
+This fork uses a single TLS feature:
+- `tls-openssl`: Uses system OpenSSL via `rustls-openssl`. **Always pass `--no-default-features -F tls-openssl`** to all cargo commands (build, test, check, clippy). The upstream default `tls-aws-lc` is not used.
+- `jemalloc`: Enables jemalloc allocator with profiling support (`tikv-jemallocator` + `jemalloc_pprof`).
+- `testing`: Enables test utility code (mock secret managers, test helpers). Automatically enabled for dev dependencies via the `ztunnel` self-dependency.
+
+Other TLS features (`tls-aws-lc`, `tls-ring`, `tls-boring`) exist in `Cargo.toml` for upstream compatibility but are not used in this fork.
+
+### TLS Mode Selection in Makefiles
+`Makefile.core.mk` reads `TLS_MODE` environment variable. For this fork, always set `TLS_MODE=openssl`:
+- `openssl` → `--no-default-features -F tls-openssl`
+- unset → falls through to default features (`tls-aws-lc`), which is **not what you want** in this fork
+
+Common build commands for this fork:
+```
+TLS_MODE=openssl make build
+TLS_MODE=openssl make test
+cargo build --no-default-features -F tls-openssl
+cargo test --no-default-features -F tls-openssl
+```
+
+### Build Profiles
+- `release`: `opt-level=3`, `codegen-units=1`, `lto=true` — fully optimized, slow build.
+- `quick-release`: Inherits release but `codegen-units=16`, `lto=false`, `incremental=true` — faster iteration.
+- `bench`: Inherits `quick-release`.
+- `symbols-release`: Inherits release with `debug=true` for profiling.
+
+### Test Architecture
+Two test crate files exist in `tests/`:
+
+**`tests/direct.rs`** — runs without special privileges:
+- Tests proxy lifecycle, shutdown, connections, config dump, DNS resolution
+- Uses `test_config()` to create a local ztunnel instance with mock identity
+- Run with `cargo test --no-default-features -F tls-openssl`
+
+**`tests/namespaced.rs`** — requires Linux `--privileged` and network namespaces:
+- Guard: `#[cfg(all(test, target_os = "linux"))]`
+- Uses `setup_netns_test!` macro to create `WorkloadManager` with real network namespaces
+- Tests run workloads as isolated namespaces with `Namespace::run()` which spawns threads in the target netns
+- Supports `Shared` and `Dedicated` test modes
+- Initializes once via `#[ctor::ctor]` calling `initialize_namespace_tests()`
+- Tests cover: captured/uncaptured traffic, waypoints (workload/service/hostname), double-HBONE, load balancing, RBAC policies, trust domain mismatch, shutdown, certificate lifecycle
+
+### Containerized Build
+When `BUILD_WITH_CONTAINER=1` (default in OSSM overrides), the Makefile delegates all targets to `common/scripts/run.sh` which runs the build inside a Docker container. The container gets:
+- `--privileged` flag (needed for namespace tests)
+- `-v /fake/path/does/not/exist:/var/run/netns` (Linux: mount point for network namespaces)
+- `-v /dev/null:/run/xtables.lock` (iptables lock file)
+
+### OSSM CI Pipeline
+- **Pre-submit** (`ossm/ci/pre-submit.sh`): Builds release binary with `tls-openssl`. No tests.
+- **Post-submit** (`ossm/ci/post-submit.sh`): Builds release binary with `tls-openssl`, uploads to `gs://maistra-prow-testing/ztunnel/ztunnel-${SHA}-${ARCH}`. Supports `amd64` and `arm64`.
+
+### Presubmit Target
+`make presubmit` is the upstream comprehensive CI gate: sets `RUSTFLAGS=-D warnings` (deny all warnings), then runs `check-features`, `test`, `lint`, and `gen-check`. For this fork, use `TLS_MODE=openssl make presubmit` or run the OSSM CI scripts directly.
+
+## Gotchas
+- **Namespaced tests need `--privileged`**: The `Makefile.overrides.mk` adds `--privileged` to Docker. Without it, `setns()` and network namespace creation fail. This gives the container more privilege than strictly necessary (see `moby/moby#42441`).
+- **Always use `--no-default-features -F tls-openssl`**: Both CI scripts hardcode this. Running `cargo build` without these flags will build with `tls-aws-lc` (upstream default), which is incorrect for this fork.
+- **`testing` feature is not default**: It's enabled via a self-dependency in `[dev-dependencies]`: `ztunnel = { path = ".", features = ["testing"] }`. This ensures test utilities are available in integration tests but not in production builds.
+- **Binary output path**: Cargo outputs to `out/rust/release/ztunnel` (via `CARGO_TARGET_DIR` set by `common/scripts/setup_env.sh`), not the default `target/release/ztunnel`. The Containerfile, release script, and CI scripts all reference this path.
+- **No test target in OSSM CI**: `ossm/ci/pre-submit.sh` (runs on-PR) and `post-submit.sh` (runs on-push) only build, they do not run tests. Tests require a privileged container, which is not available in the GitHub CI environment used for these scripts.
+- **`gen-check` depends on fuzz crate**: `make gen` updates the fuzz crate's Cargo.lock (`cd fuzz; cargo update ztunnel`). `gen-check` then verifies no uncommitted changes via `check-clean-repo`.
+- **Clippy lints configuration**: `assigning_clones = "allow"` and `borrow_interior_mutable_const = "allow"` / `declare_interior_mutable_const = "allow"` — the latter is needed for the `strng` interned string type used throughout the codebase.
+- **Protobuf code generation**: `tonic-build` and `prost-build` are build dependencies — protobuf compilation happens at build time via `build.rs`.
+- **Platform-specific dependencies**: `netns-rs` and `pprof` are Linux-only (`target.'cfg(target_os = "linux")'.dependencies`).
+
+## Dependencies & Context
+- **Istio common-files**: The `Makefile` is copied from `istio/common-files` repo. Updates via `make update-common`. Contains shared CI scripts, linting, and environment setup.
+- **Build container**: The containerized build environment provides the Rust toolchain, protobuf compiler, and other build tools. Controlled by `BUILD_WITH_CONTAINER`.
+- **OSSM downstream fork**: This is the OpenShift Service Mesh fork of upstream `istio/ztunnel`. The `ossm/ci/` directory contains OSSM-specific CI scripts that target `maistra-prow-testing` GCS bucket.
+- **`rustls-openssl` from git**: This fork pins `rustls-openssl` to a git revision (`tofay/rustls-openssl` rev `a21035c`) rather than a crates.io release, to include patches not yet published upstream.
+- **Container base image**: Uses `gcr.io/istio-release/base:master-*` as the base, which provides distroless runtime environment.
+- **Prow CI**: OSSM uses Prow for CI (`maistra-prow-testing` GCS project, `GOOGLE_APPLICATION_CREDENTIALS` for auth). Post-submit uploads binary artifacts to GCS for consumption by the build pipeline.
+- **Fuzz testing**: A separate `fuzz/` directory exists (referenced in `check-features` and `gen` targets) using `RUSTFLAGS="--cfg fuzzing"`.
+
+## Links
+- [TLS and Crypto](tls-and-crypto.md) -- OpenSSL crypto backend and TLS runtime behavior
+- [In-Pod Mode](inpod-mode.md) -- namespace tests exercise in-pod proxy lifecycle
+- [Proxy Data Plane](proxy-data-plane.md) -- integration tests verify proxy connection behavior
+- [Cargo.toml](../../Cargo.toml) -- package definition, features, dependencies
+- [Makefile.core.mk](../../Makefile.core.mk) -- core build and test targets
+- [tests/namespaced.rs](../../tests/namespaced.rs) -- network-namespace integration tests

--- a/docs/agents/dns-resolution.md
+++ b/docs/agents/dns-resolution.md
@@ -1,0 +1,113 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 0
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/dns.rs"
+    - "src/dns/server.rs"
+    - "src/dns/handler.rs"
+    - "src/dns/forwarder.rs"
+    - "src/dns/resolver.rs"
+    - "src/dns/metrics.rs"
+    - "src/dns/name_util.rs"
+  stale_flags: []
+---
+
+# DNS Resolution
+
+> This doc covers ztunnel's built-in DNS proxy: how it resolves Kubernetes service hostnames from
+> local state, forwards unknown queries upstream, and handles search domain expansion. For the
+> xDS state that feeds service/workload lookups, see [xds-and-state.md](xds-and-state.md).
+> For how DNS proxies are created per-pod in shared mode, see [inpod-mode.md](inpod-mode.md).
+
+## Key Entry Points
+- `src/dns/server.rs`: `Server::new()` — binds TCP+UDP sockets via `SocketFactory`, creates the `Store` resolver and `hickory_server::ServerFuture`. `Server::run()` drives the server until drain.
+- `src/dns/server.rs`: `Store` — the core `Resolver` implementation. Looks up hostnames against `DemandProxyState` (services by hostname, workloads by UID for headless), generates alias expansions, and falls back to upstream forwarding.
+- `src/dns/server.rs`: `forwarder_for_mode()` — factory that creates a `SystemForwarder` with either per-pod dynamic search domains (shared mode) or static system search domains (dedicated mode).
+- `src/dns/handler.rs`: `Handler` — hickory `RequestHandler` that dispatches `Query` opcodes to `Resolver::lookup()` and converts errors to appropriate DNS response codes.
+- `src/dns/forwarder.rs`: `Forwarder` — wraps `hickory_resolver::Resolver` with a custom `RuntimeProviderAdaptor` that routes TCP/UDP through ztunnel's `SocketFactory` (enabling socket creation in pod network namespaces).
+- `src/dns/resolver.rs`: `Resolver` trait and `Answer` type — abstraction over DNS resolution with an `is_authoritative` flag distinguishing locally-resolved from forwarded responses.
+- `src/dns/metrics.rs`: `Metrics` — Prometheus counters/histograms: `dns_requests`, `dns_upstream_requests`, `dns_upstream_failures`, `dns_upstream_request_duration_seconds`.
+- `src/dns/name_util.rs`: `has_domain()`, `trim_domain()` — helpers for checking and stripping DNS domain suffixes.
+- `src/app.rs:58-226`: DNS proxy lifecycle — conditionally created when `config.dns_proxy` is true, registered as a readiness task, spawned in the data plane worker pool.
+
+## Patterns & Conventions
+
+### Resolution Flow
+1. `Handler` receives a DNS request and calls `Store::lookup()`
+2. `Store` identifies the source workload via `LocalWorkloadFetcher`; returns `ServFail` if unknown
+3. Non-A/AAAA record types are immediately forwarded upstream
+4. `find_server()` builds alias list from the requested name, trying Kubernetes FQDN expansions and search domain stripping, then looks up each alias (including wildcards) against `ServiceStore::get_by_host()`
+5. If a service match is found, `get_addresses()` returns VIPs (normal services) or endpoint workload IPs (headless services), filtered by record type and client network
+6. Addresses are shuffled randomly (`addrs.shuffle(&mut rng())`) for DNS-based load balancing
+7. If the name was found via search domain stripping, a CNAME record maps the requested name to the canonical name, followed by A/AAAA records
+8. If no match is found, the request is forwarded to the upstream `SystemForwarder`
+
+### Kubernetes FQDN Expansion (`to_kube_fqdns`)
+Short names are expanded to possible Kubernetes FQDNs based on label count:
+- 1 label (`svc`): `svc.<client-ns>.svc.<cluster-domain>`
+- 2 labels (`svc.ns`): `svc.ns.svc.<cluster-domain>` and `svc.ns.<client-ns>.svc.<cluster-domain>` (pod hostname form)
+- 3 labels (`svc.ns.svc`): `svc.ns.svc.<cluster-domain>` (if third label is `svc`) and pod form
+- 4 labels: pod hostname form only (if fourth label is `svc`)
+- 5+ labels: no expansion (assumed to be FQDN already)
+
+### Search Domain Handling
+- **Shared mode**: Search domains are dynamically generated per-pod: `<ns>.svc.<cluster-domain>`, `svc.<cluster-domain>`, `<cluster-domain>`
+- **Dedicated mode**: Static search domains from ztunnel's `/etc/resolv.conf`
+- Search domains from the upstream resolver config are stripped before forwarding to avoid double-application
+
+### Wildcard Matching
+For a name like `www.example.com`, `get_wildcards()` generates: `[www.example.com, *.example.com, *.com]`. Each wildcard is checked against `ServiceStore` by hostname.
+
+### Headless Service Resolution
+Services with empty `vips` but a `.svc.cluster.local` hostname are treated as headless: `get_addresses()` resolves endpoint workload IPs via `WorkloadStore::find_uid()` instead of returning VIPs. `IpFamily` filtering on headless services prevents returning dual-stack pod IPs when the service is single-stack.
+
+### Preferred Namespace Resolution
+When multiple services share the same hostname across namespaces, resolution priority is:
+1. Client's own namespace
+2. `prefered_service_namespace` (configured per-server)
+3. First match (non-deterministic)
+
+### Forwarder Socket Integration
+`RuntimeProviderAdaptor` implements hickory's `RuntimeProvider` to route upstream DNS connections through ztunnel's `SocketFactory`. This ensures DNS forwarding works correctly in pod network namespaces (in-pod mode) with proper `SO_MARK` and netns context. TCP connections use a 5-second connect timeout (`CONNECT_TIMEOUT`).
+
+## Gotchas
+- **Only A and AAAA records handled locally**: All other record types (NS, MX, SRV, TXT, etc.) are forwarded upstream without consulting local state. `is_record_type_supported()` is the gatekeeper.
+- **IPv6 can be globally disabled**: When `ipv6_enabled` is false, AAAA records are suppressed even if services/workloads have IPv6 addresses. The server also calls `socket_factory.ipv6_enabled_localhost()` to auto-detect per-pod IPv6 support and downgrade the bind address.
+- **Default TTL is 30 seconds**: All locally-resolved records use `DEFAULT_TTL_SECONDS = 30`, regardless of the service configuration.
+- **No pod-level DNS for headless services**: Individual pod hostnames (`pod-hostname.pod-subdomain.ns.svc.cluster.local`) are not yet resolved — only the headless service name returns all endpoint IPs. See `TODO(https://github.com/istio/ztunnel/issues/1119)`.
+- **Search domains are not read from pod spec**: In shared mode, search domains are hardcoded from cluster domain rather than read from the pod's actual `/etc/resolv.conf`. See `TODO(https://github.com/istio/ztunnel/issues/555)`.
+- **Network-aware VIP filtering**: VIPs are only returned if the VIP's `network` matches the client workload's `network`. A service VIP on `nw2` will return empty records for a client on `nw1`.
+- **Headless external ServiceEntry without `.svc.cluster.local`**: External headless services (e.g., `headless.example.com`) with no VIPs are filtered out because they don't match the `.svc.cluster.local` domain check. Their queries are forwarded upstream.
+- **UDP response truncation**: Large responses (e.g., 256 A records) are automatically truncated by hickory's `ServerFuture` for UDP but sent in full over TCP.
+- **EDNS max payload**: The response EDNS payload size is set to `max(client_edns_payload, 512)`.
+- **DNS proxy waits for initial xDS sync**: The DNS proxy task blocks on `xds_rx.changed().await` in `app.rs` before starting, ensuring state is loaded before serving queries.
+
+## Dependencies & Context
+- **hickory-dns ecosystem**: `hickory_server::ServerFuture` for TCP/UDP server, `hickory_resolver` for upstream forwarding, `hickory_proto` for DNS types (Name, Record, RData). Formerly known as TrustDNS.
+- **`DemandProxyState`**: The DNS `Store` reads services and workloads from the shared proxy state. Service lookups use `get_by_host()`; headless endpoints use `find_uid()`. State is accessed via `Arc<RwLock>`.
+- **`SocketFactory` integration**: Both the DNS server binds and upstream forwarder connections go through `SocketFactory`, enabling correct operation in pod network namespaces with `SO_MARK`.
+- **`LocalWorkloadFetcher`**: Identifies the source workload for each DNS request. In shared mode, this returns the workload associated with the pod whose DNS proxy this is. In dedicated mode, it's the single local workload.
+- **Conditional creation**: DNS proxy is only created when `config.dns_proxy` is true. When enabled, it registers as a readiness dependency and runs in the data plane worker pool alongside proxy tasks.
+- **Drain integration**: Server shuts down gracefully on `DrainMode::Graceful`, immediately otherwise. TCP request timeout is 5 seconds (`DEFAULT_TCP_REQUEST_TIMEOUT`).
+
+## Links
+- [xDS and State Management](xds-and-state.md) -- service/workload state that feeds DNS lookups
+- [In-Pod Mode](inpod-mode.md) -- per-pod DNS proxy creation in shared mode
+- [Proxy Data Plane](proxy-data-plane.md) -- SocketFactory used by DNS for socket creation
+- [Observability](observability.md) -- DNS metrics exposed via the metrics endpoint
+- [src/dns/server.rs](../../src/dns/server.rs) -- core DNS server and Store resolver
+- [src/dns/forwarder.rs](../../src/dns/forwarder.rs) -- upstream DNS forwarding with SocketFactory integration

--- a/docs/agents/inpod-mode.md
+++ b/docs/agents/inpod-mode.md
@@ -1,0 +1,104 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 0
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/inpod.rs"
+    - "src/inpod/workloadmanager.rs"
+    - "src/inpod/statemanager.rs"
+    - "src/inpod/netns.rs"
+    - "src/inpod/protocol.rs"
+    - "src/inpod/config.rs"
+    - "src/inpod/packet.rs"
+    - "src/inpod/admin.rs"
+    - "src/inpod/metrics.rs"
+  stale_flags: []
+---
+
+# In-Pod Mode
+
+> This doc covers the in-pod (shared) proxy mode: how ztunnel receives workload
+> assignments from the Istio CNI node agent, manages per-pod proxy instances, and creates
+> sockets in pod network namespaces. For dedicated mode proxy operation, see
+> [proxy-data-plane.md](proxy-data-plane.md).
+
+## Key Entry Points
+- `src/inpod.rs`: `init_and_new()` — verifies syscall capabilities (setns, SO_MARK), creates `WorkloadProxyManager`. Defines `WorkloadMessage` enum (AddWorkload, KeepWorkload, DelWorkload, WorkloadSnapshotSent).
+- `src/inpod/workloadmanager.rs`: `WorkloadProxyManager` — main run loop. Connects to CNI node agent over Unix domain socket, handles reconnection with backoff, processes workload messages, manages readiness.
+- `src/inpod/statemanager.rs`: `WorkloadProxyManagerState` — tracks per-workload proxy state. Creates proxies via `ProxyFactory`, handles snapshot reconciliation, retries failed proxy starts, drains workloads on removal.
+- `src/inpod/protocol.rs`: `WorkloadStreamProcessor` — ZDS (Ztunnel Discovery Service) protocol implementation over Unix SeqPacket sockets. Sends hello/ack/nack, receives workload messages with network namespace FDs via `SCM_RIGHTS`.
+- `src/inpod/netns.rs`: `InpodNetns` — wraps a network namespace FD. `run()` switches to the workload's netns via `setns()`, executes a closure, then switches back. Identity by inode+dev comparison.
+- `src/inpod/config.rs`: `InPodConfig` — creates `InPodSocketFactory` that binds sockets within the pod's network namespace with SO_MARK. Optionally adds SO_REUSEPORT via `InPodSocketPortReuseFactory`.
+- `src/inpod/packet.rs`: SeqPacket socket `bind()` and `connect()` functions using nix — standard Unix streams don't support SeqPacket.
+- `src/inpod/admin.rs`: `WorkloadManagerAdminHandler` — tracks proxy states (Pending/Up) for the admin API. Uses reference counting to handle race between proxy task completion and factory notifications.
+
+## Patterns & Conventions
+
+### ZDS Protocol Flow
+1. Ztunnel connects to the CNI node agent via Unix SeqPacket socket at `cfg.inpod_uds`
+2. Sends `ZdsHello` with protocol version
+3. Receives workload messages: `AddWorkload` (with netns FD via SCM_RIGHTS), `KeepWorkload`, `DelWorkload`, `WorkloadSnapshotSent`
+4. Acknowledges each message with `Ack` or `Nack`
+5. On `WorkloadSnapshotSent`, reconciles: drains any proxies not mentioned in the snapshot
+
+### Snapshot Reconciliation
+When reconnecting (e.g., after CNI node agent restart), the protocol replays the full workload set:
+- `AddWorkload` messages arrive for each active workload (idempotent — skipped if proxy already running with same netns inode)
+- `KeepWorkload` messages mark existing proxies to retain
+- `WorkloadSnapshotSent` triggers `reconcile()` which drains any workloads not in `snapshot_names`
+
+### Per-Workload Proxy Lifecycle
+Each workload gets its own `drain::DrainTrigger`. On `AddWorkload`:
+1. Create `InpodNetns` from the received FD
+2. Build a `SocketFactory` that operates in the pod's network namespace
+3. Call `ProxyFactory::new_proxies_from_factory()` with the pod-specific socket factory
+4. Spawn the proxy and optional DNS proxy as Tokio tasks
+5. Track in `workload_states` HashMap
+
+On `DelWorkload`: drain the workload's proxy immediately (non-graceful).
+
+### Failed Proxy Retry
+If proxy creation fails (e.g., port conflict from a not-yet-drained old pod), the workload is placed in `pending_workloads`. A retry timer fires every 5 seconds (`RETRY_DURATION`). Once all pending workloads succeed, the retry timer is cleared and readiness is signaled.
+
+### Network Namespace Socket Factory
+`InPodSocketFactory` (`src/inpod/config.rs`) wraps `DefaultSocketFactory`:
+- `tcp_bind()` / `udp_bind()`: calls `netns.run()` to temporarily switch to the pod's netns, create/bind the socket, then switch back. Also sets `SO_MARK` on each socket.
+- `InPodSocketPortReuseFactory`: adds `SO_REUSEPORT` on bind operations. Controlled by `cfg.inpod_port_reuse`.
+
+## Gotchas
+- **CAP_NET_RAW and CAP_NET_ADMIN required**: `verify_syscalls()` checks both `setns()` and `SO_MARK` capabilities at startup, failing early if missing.
+- **Netns identity by inode**: Two netns FDs are considered equal if they have the same `(inode, dev)`. When a pod sandbox is recreated (CNI failure), the new netns has a different inode, causing ztunnel to drain the old proxy and start a new one.
+- **`setns()` switches the calling thread**: `InpodNetns::run()` calls `setns()` to the workload netns, runs the closure, then calls `setns()` back to the original netns. The second `setns()` panics on failure ("this must never fail") since being stuck in the wrong netns would be catastrophic.
+- **SeqPacket sockets**: The ZDS protocol uses Unix SeqPacket sockets (not stream), which preserve message boundaries. Standard Rust `UnixStream` doesn't support SeqPacket, so `src/inpod/packet.rs` uses raw `nix` syscalls for socket creation.
+- **SCM_RIGHTS for netns FDs**: The `AddWorkload` message carries the pod's network namespace FD via Unix domain socket ancillary data (`SCM_RIGHTS`). The protocol validates that exactly one FD is received and that it's a netns FD (via `NS_GET_NSTYPE` ioctl or nsfs check).
+- **Readiness blocks until first snapshot**: The manager starts not-ready and only becomes ready after receiving `WorkloadSnapshotSent` with no pending proxy failures.
+- **Reconnection backoff for announce errors**: If the initial `send_hello()` fails (could be CNI restart or protocol mismatch), backoff increases from 5ms to max 15s. Protocol errors (version mismatch) cause immediate shutdown.
+- **read_message is not cancel-safe**: The `read_message_and_retry_proxies()` method pins the `readmsg` future and ensures it completes even when interleaved with retry timers.
+
+## Dependencies & Context
+- **Istio CNI node agent**: The counterpart that manages iptables rules and sends workload notifications to ztunnel over ZDS. Runs as a DaemonSet alongside ztunnel.
+- **ZDS protocol** (`proto/zds.proto`): Custom protobuf protocol between ztunnel and the CNI node agent. Messages are framed by SeqPacket message boundaries, not length-prefixed.
+- **`nix` crate**: Used extensively for `setns()`, `recvmsg()`/`sendmsg()` (SCM_RIGHTS), SeqPacket socket creation, and ioctl.
+- **`hashbrown`**: Used instead of `std::collections::HashMap` in `WorkloadProxyManagerState` for `extract_if()` during reconciliation.
+- **Shared vs Dedicated mode**: In shared mode (`ProxyMode::Shared`), ztunnel manages proxies for all pods on the node. In dedicated mode, each pod runs its own ztunnel instance and in-pod management is not used.
+
+## Links
+- [Proxy Data Plane](proxy-data-plane.md) -- proxy instances created by ProxyFactory for each workload
+- [TLS and Crypto](tls-and-crypto.md) -- certificate pre-fetching triggered by new workload arrivals
+- [DNS Resolution](dns-resolution.md) -- DNS proxy optionally created per workload
+- [proto/zds.proto](../../proto/zds.proto) -- ZDS protocol definition
+- [src/inpod/statemanager.rs](../../src/inpod/statemanager.rs) -- per-workload proxy lifecycle
+- [src/inpod/netns.rs](../../src/inpod/netns.rs) -- network namespace switching

--- a/docs/agents/observability.md
+++ b/docs/agents/observability.md
@@ -1,0 +1,135 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 0
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/metrics.rs"
+    - "src/metrics/server.rs"
+    - "src/metrics/process.rs"
+    - "src/metrics/meta.rs"
+    - "src/telemetry.rs"
+    - "src/admin.rs"
+    - "src/readiness.rs"
+    - "src/readiness/server.rs"
+    - "src/proxy/metrics.rs"
+    - "src/dns/metrics.rs"
+  stale_flags: []
+---
+
+# Observability
+
+> This doc covers ztunnel's metrics, logging, admin server, and readiness subsystems.
+> For proxy data plane behavior and connection handling, see [proxy-data-plane.md](proxy-data-plane.md).
+> For DNS-specific metrics, see [dns-resolution.md](dns-resolution.md).
+
+## Key Entry Points
+- `src/metrics/server.rs`: `Server` — HTTP server exposing `/metrics` and `/stats/prometheus` endpoints. Uses `prometheus_client::encoding::text::encode` to serialize the registry. Supports OpenMetrics content negotiation via `Accept` header.
+- `src/proxy/metrics.rs`: `Metrics` — connection-level metrics: `istio_tcp_connections_opened`, `istio_tcp_connections_closed`, `istio_tcp_received_bytes`, `istio_tcp_sent_bytes`, `istio_tcp_connection_failures`, `istio_open_sockets` (gauge), `istio_on_demand_dns`. Uses `CommonTrafficLabels` with 20+ labels (source/destination workload, namespace, identity, service, locality, etc.).
+- `src/proxy/metrics.rs`: `ConnectionResult` — per-connection metric tracker. Increments `connection_opens` on creation, tracks bytes atomically, records `connection_close` and access log on drop. Pre-fetches `Counter` handles at creation to avoid ~300ns lookup per read/write.
+- `src/dns/metrics.rs`: `Metrics` — DNS-specific metrics: `istio_dns_requests`, `istio_dns_upstream_requests`, `istio_dns_upstream_failures`, `istio_dns_upstream_request_duration_seconds`.
+- `src/metrics/meta.rs`: `Metrics` — build info gauge: `istio_build{component="ztunnel", tag="<istio_version>"}`.
+- `src/metrics/process.rs`: `ProcessMetrics` — process-level metrics: `process_open_fds` (from `/dev/fd`) and `process_max_fds` (from `RLIMIT_NOFILE`).
+- `src/metrics.rs`: `Recorder`, `IncrementRecorder`, `DeferRecorder` traits — shared metric recording abstractions. `DefaultedUnknown<T>` wrapper encodes `None` as `"unknown"` in Prometheus labels.
+- `src/telemetry.rs`: `setup_logging()` — configures tracing-subscriber with Istio-compatible formatting (plain or JSON via `LOG_FORMAT` env var). `set_level()`/`get_current_loglevel()` enable runtime log level changes. Default filter: `hickory_server::server=off,info`.
+- `src/admin.rs`: `Service` — admin HTTP server with endpoints: `/config_dump`, `/logging`, `/quitquitquit`, `/debug/pprof/profile` (Linux), `/debug/pprof/heap` (jemalloc), `/` (dashboard).
+- `src/readiness.rs`: `Ready` — tracks pending startup tasks via `HashSet<String>` behind `Arc<Mutex>`. `BlockReady` guard removes task on drop. `/healthz/ready` returns 200 when all tasks complete.
+
+## Patterns & Conventions
+
+### Metric Registration
+All metrics are registered with a `prometheus_client::registry::Registry`. The registry is partitioned:
+- `sub_registry("istio")` creates an `istio_` prefix for all application metrics
+- Connection metrics: `istio_tcp_connections_opened`, `istio_tcp_connections_closed`, `istio_tcp_received_bytes`, `istio_tcp_sent_bytes`
+- DNS metrics: `istio_dns_requests`, `istio_dns_upstream_requests`, etc.
+- Build info: `istio_build`
+- Process metrics: `process_open_fds`, `process_max_fds` (no `istio_` prefix)
+
+### Connection Metrics and Access Logging
+`ConnectionResult` combines metric recording and access logging into a single object:
+1. On creation: increments `connection_opens`, pre-fetches `Counter` handles for sent/recv bytes, emits `DEBUG` access log for "connection opened"
+2. During connection: `increment_send()`/`increment_recv()` use atomic `AtomicU64` for local tracking plus direct `Counter::inc_by()` for the aggregated metric
+3. On completion: `record()` increments `connection_close`, emits `INFO`/`ERROR` access log with bytes sent/recv, duration, and response flags
+4. On drop without `record()`: automatically records with `ClosedFromDrain` error
+
+Access logs use `target: "access"` with `parent: None` to bypass span context and use a flat structure with `src.*` and `dst.*` fields.
+
+### CommonTrafficLabels
+The `CommonTrafficLabels` struct carries 20+ labels matching Istio's standard traffic metric labels. Key design choices:
+- `source_principal` is set from `DerivedWorkload` (TLS handshake identity), not from `Workload` (xDS state), because the TLS identity is most trustworthy
+- `DefaultedUnknown<T>` encodes missing values as `"unknown"` rather than empty strings
+- `OptionallyEncode<LocalityLabels>` omits locality labels entirely when not available, rather than encoding empty values
+- `ResponseFlags` encodes as `"-"` (none), `"DENY"` (auth policy), `"CONNECT"` (connection failure), `"TLS_FAILURE"`, `"H2_HANDSHAKE_FAILURE"`, `"NETWORK_POLICY"`, or `"IDENTITY_ERROR"`
+
+### Log Formatting
+Two formats configured via `LOG_FORMAT` environment variable:
+- **Plain** (`IstioFormat`): `<timestamp>\t<level>\t<target>\t<message>\t<fields>` — matches Istio's standard log format
+- **JSON** (`IstioJsonFormat`): `{"level":"info","time":"...","scope":"...","message":"..."}` — structured JSON with scope as target
+
+The log target is stripped of the `ztunnel::` prefix for brevity. Span fields are included as `:<span_name>{fields}` in plain format and nested JSON objects in JSON format.
+
+### Dynamic Log Level
+The admin server's `/logging` endpoint supports runtime log level changes:
+- `POST /logging?level=debug` — sets global level
+- `POST /logging?level=ztunnel::proxy=debug,info` — sets module-specific levels
+- `POST /logging?reset=true` — resets to default
+- `POST /logging` — lists current level
+
+Uses `tracing_subscriber::reload::Handle` to swap the filter without restarting. `hickory_server::server` is always set to `off` by default because it's noisy.
+
+### Readiness System
+`Ready` uses a `HashSet<String>` behind `Arc<Mutex>`:
+- `register_task("name")` adds a task and returns `BlockReady`
+- Dropping `BlockReady` removes the task
+- `BlockReady::subtask()` creates nested dependencies
+- `/healthz/ready` returns 200 when the set is empty, 500 with pending task names otherwise
+- Task completion logs include elapsed time since `APPLICATION_START_TIME`
+
+### Admin Config Dump
+`/config_dump` serializes the entire proxy state as JSON:
+- `DemandProxyState` (all workloads, services, policies)
+- `Config` (runtime configuration)
+- `BuildInfo` (version information)
+- Certificate dump: identity, state (Available/Initializing/Unavailable), PEM-encoded cert chains and roots with serial numbers and validity dates
+- Custom `AdminHandler` extensions (e.g., in-pod mode state)
+
+## Gotchas
+- **`CommonTrafficLabels` retains ~600 bytes per connection**: The full label set is stored in `ConnectionResult` for the connection's lifetime. The TODO notes this could be optimized by pre-fetching metric handles at initialization.
+- **Metric counter pre-fetching**: `ConnectionResult::new()` calls `get_or_create()` (~300ns) once to get the `Counter` handle, then uses direct atomic adds (~1ns) per byte increment. Do not replace this with repeated `get_or_create()` calls in the data path.
+- **Istio byte counter flip**: Istio swaps sent/received bytes for `source` reporter. Access logs unflip this: `bytes_sent` for source reporter is actually `recv` counter. See `https://github.com/istio/istio/issues/32399`.
+- **Access log on drop**: If `ConnectionResult` is dropped without calling `record()`, it automatically records with a `ClosedFromDrain` error. This is a safety net — always call `record()` explicitly.
+- **pprof/heap endpoints are conditional**: CPU profiling (`/debug/pprof/profile`) only works on Linux with `pprof` crate (10-second profile at 1000 Hz). Heap profiling (`/debug/pprof/heap`) requires the `jemalloc` feature flag.
+- **Non-blocking log writer**: `tracing_appender::non_blocking` with `lossy(false)` and 1000-line buffer. If the buffer fills, the writing thread blocks — this prevents log loss but can cause backpressure.
+- **Log filter reload is additive by default**: `set_level(false, level)` appends to the current filter. Only `set_level(true, level)` resets first. Duplicate directives are handled by `filter::Targets::parse()`.
+- **Process metrics read `/dev/fd`**: On non-Linux platforms, this path may not exist or behave differently.
+- **OpenMetrics content negotiation**: The `/metrics` endpoint returns OpenMetrics format only when the `Accept` header contains `application/openmetrics-text`. Otherwise, it falls back to plain text Prometheus exposition format.
+
+## Dependencies & Context
+- **`prometheus_client`**: The metrics library used for all metric types (Counter, Gauge, Histogram, Family). Uses the `EncodeLabelSet` derive macro for label structs. Not the more common `prometheus` crate.
+- **`tracing` / `tracing-subscriber`**: Structured logging framework. `tracing_subscriber::reload` enables runtime filter changes. `tracing_appender::non_blocking` provides async-safe stdout writing.
+- **`hyper` (via `hyper_util`)**: Both admin and metrics servers use a shared `hyper_util::Server<T>` abstraction that binds HTTP, holds typed state, and supports drain.
+- **`pprof` crate**: CPU profiling on Linux. Builds a profile guard, sleeps 10 seconds, generates pprof protobuf output.
+- **`jemalloc_pprof`**: Heap profiling via jemalloc's `prof.dump`. Requires the `jemalloc` Cargo feature.
+- **`chrono`**: Used in admin to format certificate timestamps as RFC3339.
+- **Three HTTP servers**: ztunnel runs three separate HTTP servers — admin (`config.admin_addr`), metrics/stats (`config.stats_addr`), and readiness (`config.readiness_addr`). Each binds independently.
+
+## Links
+- [Proxy Data Plane](proxy-data-plane.md) -- connection metrics originate from proxy handlers
+- [TLS and Crypto](tls-and-crypto.md) -- certificate dump in admin config_dump
+- [DNS Resolution](dns-resolution.md) -- DNS-specific metrics
+- [In-Pod Mode](inpod-mode.md) -- WorkloadManagerAdminHandler extends config_dump
+- [src/proxy/metrics.rs](../../src/proxy/metrics.rs) -- connection metrics and access logging
+- [src/admin.rs](../../src/admin.rs) -- admin API server
+- [src/telemetry.rs](../../src/telemetry.rs) -- logging setup and runtime level control

--- a/docs/agents/proxy-data-plane.md
+++ b/docs/agents/proxy-data-plane.md
@@ -1,0 +1,123 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 0
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/proxy.rs"
+    - "src/proxy/outbound.rs"
+    - "src/proxy/inbound.rs"
+    - "src/proxy/inbound_passthrough.rs"
+    - "src/proxy/socks5.rs"
+    - "src/proxy/connection_manager.rs"
+    - "src/proxy/pool.rs"
+    - "src/proxy/h2.rs"
+    - "src/proxy/h2/client.rs"
+    - "src/proxy/h2/server.rs"
+    - "src/proxy/metrics.rs"
+    - "src/proxy/util.rs"
+    - "src/copy.rs"
+    - "src/socket.rs"
+    - "src/proxyfactory.rs"
+  stale_flags: []
+---
+
+# Proxy Data Plane
+
+> This doc covers the core proxy listeners (inbound, outbound, SOCKS5), HBONE tunneling,
+> connection pooling, and bidirectional copy. For TLS/crypto providers, see [tls-and-crypto.md](tls-and-crypto.md).
+> For xDS state that feeds routing decisions, see [xds-and-state.md](xds-and-state.md).
+
+## Key Entry Points
+- `src/proxy.rs`: Top-level `Proxy` struct that owns Inbound, InboundPassthrough, Outbound, and Socks5 listeners. Defines `SocketFactory` trait, `ProxyInputs`, error types, and the `freebind_connect()` function used by all proxy paths.
+- `src/proxyfactory.rs`: `ProxyFactory` creates proxy instances with appropriate socket factories. Entry point for both dedicated mode and in-pod mode proxy creation. Also creates the ztunnel "self-proxy" listener for metrics HBONE termination (`create_ztunnel_self_proxy_listener()`).
+- `src/proxy/outbound.rs`: `Outbound` listener on port 15001. Captures pod outbound traffic, resolves destinations via xDS state, and routes via TCP, HBONE, or double HBONE.
+- `src/proxy/inbound.rs`: `Inbound` listener on port 15008. Terminates HBONE (HTTP/2 CONNECT over mTLS), validates destinations, enforces RBAC, and proxies to the local application.
+- `src/proxy/inbound_passthrough.rs`: `InboundPassthrough` listener on port 15006. Handles plaintext inbound traffic without HBONE termination.
+- `src/proxy/socks5.rs`: `Socks5` listener on port 15080. SOCKS5 proxy that resolves hostnames via the DNS resolver and delegates to `OutboundConnection::proxy_to()`.
+- `src/proxy/pool.rs`: `WorkloadHBONEPool` — HTTP/2 connection pool for outbound HBONE. Multiplexes proxied connections over a smaller number of mTLS tunnels using `pingora_pool`.
+- `src/proxy/connection_manager.rs`: `ConnectionManager` tracks live connections and `PolicyWatcher` reactively closes connections when RBAC policies change.
+- `src/copy.rs`: `copy_bidirectional()` — custom zero-copy-friendly bidirectional data copy with adaptive buffer resizing (1KB → 16KB → 256KB).
+- `src/socket.rs`: Linux-specific socket operations: `SO_ORIGINAL_DST`, `IP_TRANSPARENT`, `IP_FREEBIND`, `SO_MARK`, and a `Listener` wrapper that sets `NODELAY` and keepalive on accepted connections.
+
+## Patterns & Conventions
+
+### Outbound Routing Decision Tree
+`OutboundConnection::build_request()` resolves the destination in a specific order:
+1. Check if destination is a **service VIP** → look for a **service waypoint** → if found, route HBONE to the waypoint
+2. If service waypoint is on a **different network** → use **double HBONE** through an east-west gateway
+3. Resolve upstream via `fetch_upstream()` → check if upstream is on a different network → double HBONE through gateway
+4. Check for a **workload waypoint** on the upstream (skip if source is already the waypoint)
+5. Final destination: direct HBONE or TCP based on `InboundProtocol` of the upstream workload
+
+### Three Outbound Protocols
+- `OutboundProtocol::TCP`: Direct TCP connection, no tunneling. Used for workloads without HBONE support.
+- `OutboundProtocol::HBONE`: Single HTTP/2 CONNECT tunnel with mTLS. Standard ambient mesh path.
+- `OutboundProtocol::DOUBLEHBONE`: HBONE-in-HBONE for cross-network traffic through east-west gateways. The outer tunnel targets the gateway, the inner tunnel targets the actual destination.
+
+### Connection Lifecycle Pattern
+All listeners follow the same pattern in their `run()` method:
+1. Wrap the accept loop in `run_with_drain()` for graceful shutdown
+2. Accept connections in a loop, spawning a Tokio task per connection
+3. Each task is wrapped in `tokio::select!` with a `force_shutdown` signal
+4. The `drain` watcher is dropped when the task completes to signal completion
+5. `assertions::size_between_ref()` checks the Future size at compile time to prevent stack bloat
+
+### Adaptive Buffer Resizing in `copy_bidirectional`
+The custom `CopyBuf` future in `src/copy.rs` starts with a 1KB buffer per connection to save memory for idle connections, then:
+- After 128KB transferred → resize to ~16KB (matches TLS record size)
+- After 10MB transferred → resize to ~256KB (jumbo mode for high-bandwidth connections)
+
+This is inspired by Go's `crypto/tls` package approach. The `BufferedSplitter` trait provides a specialized `TcpStreamSplitter` that uses `TcpStream::into_split()` (lock-free) instead of generic `tokio::io::split()` (requires locking).
+
+### Connection Tracking and Live RBAC
+`ConnectionManager` maintains a `HashMap<InboundConnection, ConnectionDrain>` with reference counting. The `handle_connection!` macro races the proxied data flow against a drain watcher, so that `PolicyWatcher` can kill connections in-flight if RBAC policies change. Connections that become disallowed are drained immediately.
+
+### Socket Factory Abstraction
+`SocketFactory` trait (`src/proxy.rs:62`) abstracts TCP/UDP socket creation. Two implementations:
+- `DefaultSocketFactory`: sets NODELAY, configurable keepalive, and TCP_USER_TIMEOUT
+- `MarkSocketFactory`: wraps `DefaultSocketFactory` and adds `SO_MARK` for packet marking (used with iptables rules)
+
+In-pod mode provides its own socket factory to create sockets within the pod's network namespace.
+
+## Gotchas
+- **Self-call prevention**: All listeners check `cfg.illegal_ports` to prevent recursive calls that could infinite-loop. The outbound also checks `dest_addr.ip().is_loopback()` in combination with illegal ports.
+- **`freebind_connect` timeout**: All outbound TCP connections have a hard 10-second timeout (`CONNECTION_TIMEOUT`). If connecting to port 15008 times out, the error message hints at NetworkPolicy blocking HBONE.
+- **PROXY protocol TLV**: Inbound uses a custom TLV type `0xD0` for source identity in the PROXY protocol header. This is a non-standard extension.
+- **Inbound IP validation**: `validate_destination()` checks that the TCP destination IP matches the HBONE `:authority` IP unless the workload has an application tunnel or is acting as a waypoint. Mismatches are rejected with `IPMismatch`.
+- **Double HBONE SANs split**: When using double HBONE, `upstream_sans` (for the gateway) and `final_sans` (for the actual workload) are different. The outer tunnel validates gateway identity, the inner tunnel validates the workload identity.
+- **Future size assertions**: `assertions::size_between_ref()` is called on spawned connection handlers to catch memory regressions. If you add fields to connection state, these may fail at compile time.
+- **`handle_connection!` is a macro**: Due to stack frame size issues with async functions, the RBAC drain-select pattern is a macro rather than a function. This saves ~1KB per connection.
+- **Inbound self-proxy and `disable_inbound_freebind`**: When ztunnel proxies to its own endpoints (metrics), `disable_inbound_freebind` is set to `true` to avoid using the external client's IP as source for internal connections.
+
+## Dependencies & Context
+- **HBONE protocol**: HTTP/2 CONNECT-based tunneling, the core transport for Istio ambient mesh. All inbound mTLS traffic arrives on port 15008 as HBONE.
+- **`pingora_pool`**: Cloudflare's Pingora connection pool crate, used for the `WorkloadHBONEPool`. The pool uses hash-based keying (DefaultHasher) with a deep-equality guard to prevent hash collisions from crossing workload streams. The pool uses per-key `tokio::sync::Mutex` locks to prevent thundering herd when many tasks request connections to the same destination simultaneously.
+- **`h2` crate**: Low-level HTTP/2 implementation used directly (not through hyper) for both the HBONE client and server. Ping/pong health checking runs with 10s interval and 20s timeout per connection.
+- **Waypoint proxies**: Ztunnel routes traffic through waypoints (Envoy-based L7 proxies) when workloads or services have waypoint configuration. The "sandwich" pattern means ztunnel → waypoint → ztunnel on the same node, using application tunnels (PROXY protocol) for the second hop.
+- **East-West gateways**: Cross-network traffic uses double HBONE through designated gateway workloads. The outer HBONE carries the service hostname in the `:authority` header so the gateway can route without terminating the inner tunnel.
+- **`ppp` crate**: Used for PROXY protocol v2 encoding in `write_proxy_protocol()`.
+- **Tracing**: Each connection gets a `TraceParent` (W3C trace context format) either from the incoming HBONE headers or generated fresh for outbound. Baggage headers carry workload metadata.
+- **Drain system**: `DrainWatcher`/`DrainTrigger` pairs provide graceful shutdown. The `run_with_drain()` function coordinates the accept loop shutdown with a configurable `self_termination_deadline`.
+
+## Links
+- [TLS and Crypto](tls-and-crypto.md) -- OpenSSL-backed TLS used by inbound/outbound HBONE connections
+- [xDS and State Management](xds-and-state.md) -- workload/service/policy state that drives routing decisions
+- [In-Pod Mode](inpod-mode.md) -- provides per-pod socket factories and proxy lifecycle
+- [Observability](observability.md) -- metrics reported by `ConnectionResult` and `proxy::metrics`
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) -- threading model and port assignments
+- [src/proxy.rs](../../src/proxy.rs) -- top-level proxy module
+- [src/proxy/pool.rs](../../src/proxy/pool.rs) -- HBONE connection pool
+- [src/copy.rs](../../src/copy.rs) -- bidirectional copy with adaptive buffers

--- a/docs/agents/tls-and-crypto.md
+++ b/docs/agents/tls-and-crypto.md
@@ -1,0 +1,111 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 20
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/tls.rs"
+    - "src/tls/lib.rs"
+    - "src/tls/workload.rs"
+    - "src/tls/certificate.rs"
+    - "src/tls/control.rs"
+    - "src/tls/csr.rs"
+    - "src/tls/crl.rs"
+    - "src/tls/mock.rs"
+    - "src/identity.rs"
+    - "src/identity/manager.rs"
+    - "src/identity/caclient.rs"
+    - "src/identity/auth.rs"
+    - "src/cert_fetcher.rs"
+  stale_flags: []
+---
+
+# TLS and Crypto
+
+> This doc covers TLS via rustls with the OpenSSL crypto backend, certificate management,
+> SPIFFE identity, and the CA client. This OSSM fork exclusively uses the `tls-openssl` feature.
+> For how TLS connections are established in the proxy, see [proxy-data-plane.md](proxy-data-plane.md).
+> For control plane xDS connections, see [xds-and-state.md](xds-and-state.md).
+
+## Key Entry Points
+- `src/tls/lib.rs`: Crypto provider selection via `provider()` function. Defines `CRYPTO_PROVIDER` string and `tls_versions()` for TLS 1.2/1.3 support. The code contains four feature-gated implementations (`tls-aws-lc`, `tls-ring`, `tls-boring`, `tls-openssl`) inherited from upstream, but this fork exclusively builds with `tls-openssl`, which selects `rustls-openssl` as the crypto backend.
+- `src/tls/certificate.rs`: `WorkloadCertificate` — holds leaf cert, chain, private key, and root store. `server_config(crl_manager)` builds inbound TLS config with optional CRL checking; `client_config(identity)` builds raw `ClientConfig`; `outbound_connector(identity)` wraps it in `OutboundConnector`. Certificate refresh at half-life via `refresh_at()`.
+- `src/tls/crl.rs`: `CrlManager` — watches a directory for CRL PEM files, hot-reloads them via `notify` debouncer. `get_crl_ders()` returns current CRLs for use in `WebPkiClientVerifier`. Fail-open for unknown revocation status.
+- `src/tls/workload.rs`: `InboundAcceptor` (TLS server), `OutboundConnector` (TLS client), `IdentityVerifier` (custom SPIFFE URI SAN verification), `TrustDomainVerifier` (inbound trust domain enforcement).
+- `src/tls/control.rs`: `ControlPlaneAuthentication` and `TlsGrpcChannel` for control plane gRPC connections to istiod. `RootCertManager` watches CA root cert file for changes and signals channel rebuild. `grpc_connector()` creates the hyper-based gRPC client.
+- `src/tls/csr.rs`: CSR generation, feature-gated per crypto backend.
+- `src/identity/manager.rs`: `SecretManager` — certificate caching and lifecycle. `Worker` runs a background task managing fetch/refresh/forget with priority queuing. `Identity` is the SPIFFE identity type (`spiffe://{td}/ns/{ns}/sa/{sa}`).
+- `src/identity/caclient.rs`: `CaClient` — gRPC client for Istio's certificate authority (istiod). Sends `IstioCertificateRequest` with CSR, validates returned certificate SANs. Supports impersonated identity for shared mode.
+- `src/cert_fetcher.rs`: `CertFetcher` trait for proactive certificate pre-fetching. `CertFetcherImpl` only pre-fetches for local-node workloads in shared mode.
+
+## Patterns & Conventions
+
+### Crypto via Rustls
+All crypto goes through `rustls` with a pluggable `CryptoProvider`. The `provider()` function in `src/tls/lib.rs` returns the provider based on the active Cargo feature. The codebase retains four feature-gated backends from upstream (`tls-aws-lc`, `tls-ring`, `tls-boring`, `tls-openssl`), but this fork only builds and tests with `tls-openssl`, which uses `rustls-openssl` to delegate cryptographic operations to the system OpenSSL. Cipher suites default to TLS 1.3 `AES_256_GCM_SHA384` and `AES_128_GCM_SHA256`; TLS 1.2 (when `TLS12_ENABLED`) adds `ECDHE_ECDSA_WITH_AES_*` and `ECDHE_RSA_WITH_AES_*` suites. The `MESH_CIPHER_SUITES` environment variable (OSSM-specific, OpenSSL only) overrides the TLS 1.3 cipher suite list at startup — comma-separated names like `TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256`.
+
+### CRL (Certificate Revocation List) Support
+`CrlManager` (`src/tls/crl.rs`) watches a directory for CRL PEM files and hot-reloads them using the `notify` crate with debouncing. `server_config()` in `WorkloadCertificate` passes CRLs to `WebPkiClientVerifier` for inbound connections. Revocation checking is fail-open (`allow_unknown_revocation_status`). Outbound CRL checking is not yet implemented.
+
+### PQC (Post-Quantum Cryptography) Support
+When `PQC_ENABLED` is true, the `tls-openssl` backend requires OpenSSL >= 3.5.0 at both compile and runtime; panics otherwise.
+
+### Custom SPIFFE SAN Verification
+Rustls doesn't natively validate URI SANs. `IdentityVerifier` in `src/tls/workload.rs` implements `ServerCertVerifier` with custom SAN checking: it verifies the cert chain against the root store, then extracts SPIFFE URIs from x509 SAN extensions and matches against expected identities. Similarly, `TrustDomainVerifier` wraps the standard `ClientCertVerifier` to add trust domain checks on inbound connections.
+
+### Certificate Lifecycle in SecretManager
+`SecretManager` (`src/identity/manager.rs`) manages certificate caching:
+1. Certificates are requested via `fetch_certificate(id)` with a `Priority` (Background, Warmup, RealTime)
+2. A `Worker` background task processes requests using a `KeyedPriorityQueue` — RealTime requests jump ahead of Background
+3. Certificates are cached in `HashMap<Identity, CertChannel>` with `watch::channel` for async notification
+4. Certificates refresh at half-life (`not_before + (not_after - not_before) / 2`)
+5. On fetch failure, existing valid certificates are retained until expiry; retry uses per-identity exponential backoff (500ms initial, 150s max)
+6. Concurrency is capped at 8 concurrent CA requests
+
+### Certificate Pre-fetching
+`CertFetcherImpl` (`src/cert_fetcher.rs`) proactively fetches certificates for workloads on the local node that support HBONE. This reduces first-request latency. Only active in `ProxyMode::Shared`.
+
+### Root Cert Hot-Reload
+`RootCertManager` (`src/tls/control.rs`) watches the CA root cert's parent directory for filesystem changes (handles Kubernetes ConfigMap atomic symlink swaps). When a change is detected, the gRPC channel to istiod is rebuilt on the next `fetch_certificate` call. Uses a 2-second debounce via the `notify` crate.
+
+## Gotchas
+- **TLS session resumption is disabled** for outbound workload connections (`cc.resumption = Resumption::disabled()`) and SNI is also disabled (`cc.enable_sni = false`) since ztunnel uses dummy IP addresses for SNI.
+- **ALPN is always `h2`** for both server and client workload configs. This is hardcoded, not configurable.
+- **CSR generation is not pluggable**: CSR generation in `src/tls/csr.rs` uses direct crypto library calls guarded by `cfg` features, not the rustls provider abstraction. Each backend has its own CSR implementation; in this fork, the `tls-openssl` path uses the `openssl` crate directly.
+- **`TLS12_ENABLED`, `PQC_ENABLED`, and `MESH_CIPHER_SUITES` are runtime flags** (from environment/config), not compile-time features. The cipher suites and key exchange groups are selected at process startup based on these flags.
+- **CRL checking is fail-open**: `allow_unknown_revocation_status()` means certificates with unknown revocation status (e.g., no CRL covers that CA) are accepted. Only explicitly revoked certificates are rejected.
+- **CRL is inbound-only**: CRL support is wired into `server_config()` for inbound connections. Outbound CRL checking (`client_config`) is not yet implemented.
+- **Impersonated identity**: In shared mode (`enable_impersonated_identity = true`), the CA client includes `ImpersonatedIdentity` metadata in the CSR request so istiod issues certificates for specific workload identities. The response SAN is validated to match the requested identity.
+- **`OutboundConnector::connect()` uses a dummy IP** (`0.0.0.0`) for the `ServerName` because actual SAN verification is done by the custom `IdentityVerifier`, not by rustls's built-in hostname verification.
+- **Root cert chain splitting**: The Istio CA API returns a flat cert chain where the last entry may contain multiple concatenated root certificates. `WorkloadCertificate::new()` handles this by splitting and parsing them individually.
+- **gRPC keepalive settings** for the CA connection match Istio's Envoy bootstrap: 300s keepalive time, 75s interval, 9 retries, 5s connect timeout.
+
+## Dependencies & Context
+- **TLS 1.2 exists for FIPS mode**: TLS 1.2 support (`TLS12_ENABLED` flag) exists specifically because istiod (Go) cannot explicitly configure TLS 1.3 cipher suites when FIPS is enabled, so it falls back to TLS 1.2. Without this flag, ztunnel couldn't communicate with istiod in FIPS mode.
+- **rustls**: Core TLS library with pluggable crypto providers. All TLS operations go through rustls — no direct OpenSSL TLS calls for the connection layer.
+- **`rustls-openssl`**: The crypto backend used by this fork. Provides OpenSSL-based cryptographic operations to rustls. Built with `features = ["tls12"]` for TLS 1.2 support.
+- **Other crypto backends (present in code, not used)**: The codebase also contains feature-gated support for `aws-lc-rs` (upstream default), `ring` (pure Rust), and `boring-rustls-provider` (FIPS via BoringSSL). These exist for upstream compatibility but are not built or tested in this fork.
+- **SPIFFE identity**: All mesh identities are SPIFFE URIs: `spiffe://{trust_domain}/ns/{namespace}/sa/{service_account}`. Parsed via `Identity::from_str()` and stored as the `Identity` enum.
+- **Istio CA (istiod)**: Certificate signing happens via gRPC (`IstioCertificateService.CreateCertificate`). The CSR is generated locally, sent to istiod, and the signed certificate chain is returned.
+- **`x509_parser`**: Used for parsing X.509 certificates, extracting SANs, and validating expiration.
+- **`openssl` / `openssl-sys`**: Direct OpenSSL bindings used for CSR generation in `src/tls/csr.rs`.
+- **`tls-listener`**: Provides the `AsyncTls` trait used by `InboundAcceptor` to accept TLS connections on the inbound listener.
+- **`keyed_priority_queue`**: Used by the `Worker` for priority-based certificate fetch scheduling.
+- **`notify`**: Filesystem watcher for CA root cert rotation detection.
+
+## Links
+- [Proxy Data Plane](proxy-data-plane.md) -- uses TLS for inbound/outbound HBONE connections
+- [xDS and State Management](xds-and-state.md) -- control plane connection uses `TlsGrpcChannel`
+- [Build and Testing](build-and-testing.md) -- build with `--no-default-features -F tls-openssl`
+- [src/tls/lib.rs](../../src/tls/lib.rs) -- crypto provider selection
+- [src/identity/manager.rs](../../src/identity/manager.rs) -- certificate lifecycle management
+- [src/identity/caclient.rs](../../src/identity/caclient.rs) -- CA gRPC client

--- a/docs/agents/xds-and-state.md
+++ b/docs/agents/xds-and-state.md
@@ -1,0 +1,123 @@
+---
+scribe:
+  scan: "c0eb538903d7019b3401d4c399e9641f0e0c4eff"
+  freshness: 100
+  human_input: 0
+  completeness: 100
+  inferred_sections:
+    - id: key-entry-points
+      heading: "## Key Entry Points"
+    - id: patterns--conventions
+      heading: "## Patterns & Conventions"
+    - id: gotchas
+      heading: "## Gotchas"
+    - id: dependencies--context
+      heading: "## Dependencies & Context"
+    - id: links
+      heading: "## Links"
+  watch_paths:
+    - "src/xds.rs"
+    - "src/xds/client.rs"
+    - "src/xds/types.rs"
+    - "src/xds/metrics.rs"
+    - "src/state.rs"
+    - "src/state/workload.rs"
+    - "src/state/service.rs"
+    - "src/state/policy.rs"
+    - "src/rbac.rs"
+  stale_flags: []
+---
+
+# xDS and State Management
+
+> This doc covers the xDS client (delta ADS), the in-memory proxy state (workloads, services,
+> policies), RBAC enforcement, and load balancing. For how the proxy uses this state to route
+> traffic, see [proxy-data-plane.md](proxy-data-plane.md). For TLS on the xDS connection,
+> see [tls-and-crypto.md](tls-and-crypto.md).
+
+## Key Entry Points
+- `src/state.rs`: `ProxyState` (workloads, services, policies stores), `DemandProxyState` (adds on-demand fetching and DNS resolution), `ProxyStateManager` (creates xDS client or local config loader and wires up state). Contains RBAC evaluation logic in `DemandProxyState::assert_rbac()` and upstream resolution in `ProxyState::find_upstream()`.
+- `src/xds.rs`: `ProxyStateUpdateMutator` applies xDS updates to `ProxyState`. Implements `Handler<XdsWorkload>`, `Handler<XdsAddress>`, and `Handler<XdsAuthorization>`. Also contains `LocalClient` for file-based config in testing.
+- `src/xds/client.rs`: `AdsClient` — delta ADS gRPC client. Manages subscriptions, on-demand requests, reconnection with backoff, and NACK handling. `Config` builder pattern for registering type-specific handlers.
+- `src/state/workload.rs`: `Workload` struct and `WorkloadStore` — indexed by UID and IP address. Defines `InboundProtocol`, `OutboundProtocol`, `NetworkMode`, `HealthStatus`, `Locality`, `GatewayAddress`, `ApplicationTunnel`.
+- `src/state/service.rs`: `Service` struct and `ServiceStore` — indexed by VIP (NetworkAddress), CIDR VIP (NetworkCidr), and hostname. Services now support CIDR-based VIPs alongside exact-IP VIPs. `EndpointSet` maps workload UIDs to endpoints with port mappings.
+- `src/state/policy.rs`: `PolicyStore` — stores RBAC `Authorization` policies indexed by namespace and key. Uses `watch::channel` to notify `PolicyWatcher` of changes.
+- `src/rbac.rs`: `Authorization` and `RbacMatch` types for L4 RBAC policy evaluation. Supports allow/deny actions with namespace, global, and workload-selector scopes.
+
+## Patterns & Conventions
+
+### Delta ADS Protocol
+The xDS client uses **delta ADS** (Aggregated Discovery Service), not SotW (State of the World). This means:
+- Resources are sent incrementally (updates + removals) rather than full snapshots
+- The client tracks `known_resources` per type URL
+- On-demand requests use `resource_names_subscribe` to request specific resources by name
+- NACKs are sent for individual resources that fail to decode or process, not for the entire response
+
+### Three xDS Resource Types
+1. `ADDRESS_TYPE` (`istio.io/address`): Carries both workloads and services in a union type (`XdsAddress`). Workloads are keyed by UID, services by `namespace/hostname`.
+2. `AUTHORIZATION_TYPE` (`istio.io/authorization`): RBAC policies. These disable on-demand (`no_on_demand() -> true`) since policies must be fully loaded.
+3. Workload type (legacy): Direct workload resources, handled by `Handler<XdsWorkload>`.
+
+### State Store Architecture
+`ProxyState` is behind `Arc<RwLock<ProxyState>>`:
+- `WorkloadStore`: dual-indexed by `by_uid` (HashMap) and `by_addr` (HashMap of NetworkAddress to UID). Uses a `watch::Sender` to notify subscribers when workloads are added, enabling `wait_for_workload()`.
+- `ServiceStore`: indexed by VIP (`by_vip`), hostname (`by_host`), and has `staged_services` for endpoints that arrive before their service.
+- `PolicyStore`: indexed by key (`by_key`) and namespace (`by_namespace`). Uses `watch::channel` to notify `PolicyWatcher` in the connection manager.
+
+### On-Demand Resource Fetching
+`DemandProxyState` wraps `ProxyState` with a `Demander` (if xDS is configured). When a workload or address is not found locally:
+1. `fetch_on_demand()` sends a subscription request via the xDS client
+2. The client adds the resource name to `resource_names_subscribe` in the next delta request
+3. The caller waits for the response via a oneshot channel
+4. After receiving, the state is checked again
+
+### RBAC Evaluation Order
+`DemandProxyState::assert_rbac()` follows Istio's documented order:
+1. Collect all DENY and ALLOW policies matching the destination workload (by namespace, global, and workload-selector)
+2. If any DENY policy matches → deny
+3. If no ALLOW policies exist → allow
+4. If any ALLOW policy matches → allow
+5. Otherwise → deny
+
+### Load Balancing
+`ProxyState::load_balance()` supports three modes via `LoadBalancerMode`:
+- `Standard`: Random selection among healthy endpoints
+- `Failover`: Rank endpoints by locality match (network, region, zone, subzone, node, cluster) and select from highest-ranked group
+- `Strict`: Like failover but requires full match, otherwise no endpoint is selected
+- `Passthrough`: Bypass load balancing, connect directly to the original destination
+
+Endpoints are weighted by `workload.capacity` (as `u64`), using `choose_weighted()` from `rand`.
+
+### XDS Update Processing Pattern
+`Handler::handle()` receives an iterator of `XdsUpdate<T>` (either `Update` or `Remove`). The `ProxyStateUpdater` implementation:
+1. Takes the write lock on `ProxyState`
+2. Processes each update individually, collecting rejected configs
+3. For authorization updates, sends a notification via `PolicyStore::send()` even if some configs were rejected (partial success)
+
+## Gotchas
+- **Workload removal clears certs**: When a workload is removed and it was the last one with that identity on the node, `CertFetcher::clear_cert()` is called. This doesn't happen during re-insertion (remove-before-insert pattern).
+- **Staged services**: Endpoints may arrive before their service definition. `ServiceStore` stores these in `staged_services` and merges them when the service is later inserted.
+- **On-demand is per-type**: Authorization policies have `no_on_demand() -> true`, meaning they are never fetched on-demand. Only address/workload types support on-demand.
+- **WorkloadStore subscriber**: `WorkloadStore` uses a `watch::Sender<()>` to notify when workloads change. `wait_for_workload()` subscribes before checking state to avoid race conditions.
+- **Service lookup order**: `find_address()` checks workloads first, then falls back to services. `find_hostname()` checks services first, then falls back to a slow O(n) workload scan.
+- **DNS resolution for hostname workloads**: If a workload has a hostname but no IPs, `DemandProxyState` resolves it using `hickory_resolver`, preferring the same IP family as the original request.
+- **Host network mode**: Workloads with `NetworkMode::HostNetwork` share IPs. When looking up by address for non-service traffic, ztunnel returns passthrough (no workload association) to avoid ambiguity.
+- **xDS reconnection**: The ADS client reconnects with backoff on connection failures. Each reconnection re-subscribes to all known resource types and sends initial resource lists.
+
+## Dependencies & Context
+- **Delta ADS gRPC**: xDS protocol variant that sends incremental updates. Uses `tonic` for gRPC and `prost` for protobuf decoding. The proto definitions are in `proto/` (workload.proto, authorization.proto, xds.proto).
+- **`DemandProxyState`**: The primary interface used by proxy components. It wraps the raw state with on-demand fetching and DNS resolution capabilities. Cloneable and thread-safe.
+- **`ProxyStateManager`**: Top-level orchestrator created in `app.rs`. Creates either an `AdsClient` (when `xds_address` is configured) or a `LocalClient` (for file-based testing config). Produces the `DemandProxyState` used by all proxy listeners.
+- **`hickory_resolver`**: DNS resolver used by `DemandProxyState` for resolving hostname-based workloads. Configured via `dns_resolver_cfg` and `dns_resolver_opts` from the proxy config.
+- **`keyed_priority_queue`**: Not used here (used in identity manager), but the state module uses `rand::seq::IndexedRandom::choose_weighted` for load balancing.
+- **Local config**: `LocalClient` loads workloads, services, and policies from YAML files or dynamic channels (for tests). It clears all state on reload.
+
+## Links
+- [Proxy Data Plane](proxy-data-plane.md) -- consumes state for routing decisions
+- [TLS and Crypto](tls-and-crypto.md) -- xDS connection uses `TlsGrpcChannel`; cert pre-fetching triggered by workload updates
+- [In-Pod Mode](inpod-mode.md) -- manages per-pod proxy instances that share the same state
+- [Observability](observability.md) -- xDS metrics tracked in `src/xds/metrics.rs`
+- [proto/workload.proto](../../proto/workload.proto) -- workload/service protobuf definitions
+- [proto/authorization.proto](../../proto/authorization.proto) -- RBAC policy protobuf definitions
+- [src/state.rs](../../src/state.rs) -- proxy state and RBAC evaluation
+- [src/xds/client.rs](../../src/xds/client.rs) -- delta ADS client implementation


### PR DESCRIPTION
AGENTS.md at repo root with project overview and build reference.
CLAUDE.md with @include and Claude-specific instructions.
docs/agents/ topic files covering each subsystem.

Uses codebase-scribe format (not an industry standard).
All examples use --no-default-features -F tls-openssl.